### PR TITLE
added metrics related to the motion sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ remo_illumination{id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",name="Living Remo"} 
 # HELP remo_temperature The temperature of the remo device
 # TYPE remo_temperature gauge
 remo_temperature{id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",name="Living Remo"} 28.2
+# HELP remo_motion The motion of the remo device
+# TYPE remo_motion gauge
+remo_motion{id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",name="Living Remo"} 1.568608471e+09
 ```
 
 ## Usage

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -34,6 +34,12 @@ var (
 		[]string{"name", "id"}, nil,
 	)
 
+	motion = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "motion"),
+		"The motion of the remo device",
+		[]string{"name", "id"}, nil,
+	)
+
 	rateLimitLimit = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "x_rate_limit_limit"),
 		"The rate limit for the remo API",
@@ -80,6 +86,7 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- temperature
 	ch <- humidity
 	ch <- illumination
+	ch <- motion
 	ch <- rateLimitLimit
 	ch <- rateLimitReset
 	ch <- rateLimitRemaining
@@ -107,6 +114,7 @@ func (e *Exporter) processMetrics(devicesResult *types.GetDevicesResult, ch chan
 		ch <- prometheus.MustNewConstMetric(temperature, prometheus.GaugeValue, d.NewestEvents.Temperature.Value, d.Name, d.ID)
 		ch <- prometheus.MustNewConstMetric(humidity, prometheus.GaugeValue, d.NewestEvents.Humidity.Value, d.Name, d.ID)
 		ch <- prometheus.MustNewConstMetric(illumination, prometheus.GaugeValue, d.NewestEvents.Illumination.Value, d.Name, d.ID)
+		ch <- prometheus.MustNewConstMetric(motion, prometheus.GaugeValue, float64(d.NewestEvents.Motion.CreatedAt.Unix()), d.Name, d.ID)
 	}
 
 	if devicesResult.Meta != nil {

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -2,6 +2,7 @@ package exporter_test
 
 import (
 	"strconv"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kenfdev/remo-exporter/config"
@@ -78,6 +79,8 @@ var _ = Describe("Exporter", func() {
 			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_illumination", help: "The illumination of the remo device", constLabels: {}, variableLabels: [name id]}`))
 			d = (<-ch)
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_motion", help: "The motion of the remo device", constLabels: {}, variableLabels: [name id]}`))
+			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_x_rate_limit_limit", help: "The rate limit for the remo API", constLabels: {}, variableLabels: []}`))
 			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_x_rate_limit_reset", help: "The time in which the rate limit for the remo API will be reset", constLabels: {}, variableLabels: []}`))
@@ -104,6 +107,10 @@ var _ = Describe("Exporter", func() {
 					},
 					Illumination: &types.SensorValue{
 						Value: 40.0,
+					},
+					Motion: &types.SensorValue{
+						CreatedAt: time.Now(),
+						Value:     1.0,
 					},
 				},
 			}
@@ -143,6 +150,12 @@ var _ = Describe("Exporter", func() {
 			m = (<-ch).(prometheus.Metric)
 			m2 = readGauge(m)
 			Expect(m2.value).To(Equal(device.NewestEvents.Illumination.Value))
+			Expect(m2.labels["name"]).To(Equal(device.Name))
+			Expect(m2.labels["id"]).To(Equal(device.ID))
+
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(Equal(float64(device.NewestEvents.Motion.CreatedAt.Unix())))
 			Expect(m2.labels["name"]).To(Equal(device.Name))
 			Expect(m2.labels["id"]).To(Equal(device.ID))
 

--- a/types/types.go
+++ b/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 type User struct {
 	ID        string `json:"id"`
 	Nickname  string `json:"nickname"`
@@ -7,13 +9,14 @@ type User struct {
 }
 
 type SensorValue struct {
-	Value     float64 `json:"val"`
-	CreatedAt string  `json:"created_at"`
+	Value     float64   `json:"val"`
+	CreatedAt time.Time `json:"created_at"`
 }
 type Event struct {
 	Temperature  *SensorValue `json:"te"`
 	Humidity     *SensorValue `json:"hu"`
 	Illumination *SensorValue `json:"il"`
+	Motion       *SensorValue `json:"mo"`
 }
 
 type Device struct {


### PR DESCRIPTION
## Description

Added metrics for motion sensor.

## Related Issue

none

## Motivation and Context

This is because the value of the motion sensor can be obtained by API.

This value seems to be available from around June 20, 2019.
refs: https://zlog.hateblo.jp/entry/2019/07/07/Nature-remo-motion-sensor

## How Has This Been Tested?

Added a test that motion sensor metrics can be obtained.
Tested on local macOS and confirmed pass.

macOS: 10.14.6
golang: 1.13

refs: https://github.com/kenfdev/remo-exporter/pull/13/files#diff-08847f453c9146c4bd1c3acf66d376db