### PR TITLE
Fix SEGV when a device lacks some events

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -111,10 +111,18 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 func (e *Exporter) processMetrics(devicesResult *types.GetDevicesResult, ch chan<- prometheus.Metric) error {
 	for _, d := range devicesResult.Devices {
-		ch <- prometheus.MustNewConstMetric(temperature, prometheus.GaugeValue, d.NewestEvents.Temperature.Value, d.Name, d.ID)
-		ch <- prometheus.MustNewConstMetric(humidity, prometheus.GaugeValue, d.NewestEvents.Humidity.Value, d.Name, d.ID)
-		ch <- prometheus.MustNewConstMetric(illumination, prometheus.GaugeValue, d.NewestEvents.Illumination.Value, d.Name, d.ID)
-		ch <- prometheus.MustNewConstMetric(motion, prometheus.GaugeValue, float64(d.NewestEvents.Motion.CreatedAt.Unix()), d.Name, d.ID)
+		if d.NewestEvents.Temperature != nil {
+			ch <- prometheus.MustNewConstMetric(temperature, prometheus.GaugeValue, d.NewestEvents.Temperature.Value, d.Name, d.ID)
+		}
+		if d.NewestEvents.Humidity != nil {
+			ch <- prometheus.MustNewConstMetric(humidity, prometheus.GaugeValue, d.NewestEvents.Humidity.Value, d.Name, d.ID)
+		}
+		if d.NewestEvents.Illumination != nil {
+			ch <- prometheus.MustNewConstMetric(illumination, prometheus.GaugeValue, d.NewestEvents.Illumination.Value, d.Name, d.ID)
+		}
+		if d.NewestEvents.Motion != nil {
+			ch <- prometheus.MustNewConstMetric(motion, prometheus.GaugeValue, float64(d.NewestEvents.Motion.CreatedAt.Unix()), d.Name, d.ID)
+		}
 	}
 
 	if devicesResult.Meta != nil {


### PR DESCRIPTION
## Description

device.newest_events.* might be nil when a device lacks a event. For
instance, Nature Remo E series always lack the events provided at
Nature Remo series.

```json
  {
    "name": "Remo E lite",
    "id": "[deducted]",
    "created_at": "[deducted]",
    "updated_at": "[deducted]",
    "mac_address": "[deducted]",
    "bt_mac_address": "[deducted]",
    "serial_number": "[deducted]",
    "firmware_version": "Remo-E-lite/1.1.2",
    "temperature_offset": 0,
    "humidity_offset": 0,
    "users": [
      {
        "id": "[deducted]",
        "nickname": "[deducted]",
        "superuser": true
      }
    ],
    "newest_events": {}
  }
```

## Motivation and Context

Fix segmentation fault at /metrics when Nature Remo E is present at /1/devices API.

## How Has This Been Tested?

Confirmed the SEGV no longer occurs with my local build including this patch.