### PR TITLE
Support for Remo E lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/kenfdev/remo-exporter.svg?style=svg)](https://circleci.com/gh/kenfdev/remo-exporter) [![codecov](https://codecov.io/gh/kenfdev/remo-exporter/branch/master/graph/badge.svg)](https://codecov.io/gh/kenfdev/remo-exporter)
 
-Exposes Nature Remo devices metrics to Prometheus.
+Exposes Nature Remo and Nature Remo E lite devices metrics to Prometheus.
 
 ## Configuration
 
@@ -39,6 +39,17 @@ remo_temperature{id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",name="Living Remo"} 2
 # HELP remo_motion The motion of the remo device
 # TYPE remo_motion gauge
 remo_motion{id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",name="Living Remo"} 1.568608471e+09
+```
+
+If you have a Nature Remo E lite, you can also get the following metrics:
+
+```plain
+# HELP remo_cumulative_electric_energy_kilowatt The cumulative electric energy of the remo e lite
+# TYPE remo_cumulative_electric_energy_kilowatt counter
+remo_cumulative_electric_energy_kilowatt{id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",name="Remo E lite"} 5094.8
+# HELP remo_measured_instantaneous_energy_watt The measured instantaneous energy of the remo e lite
+# TYPE remo_measured_instantaneous_energy_watt gauge
+remo_measured_instantaneous_energy_watt{id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",name="Remo E lite"} 529
 ```
 
 ## Usage

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -40,6 +40,18 @@ var (
 		[]string{"name", "id"}, nil,
 	)
 
+	cumulativeElectricEnergy = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "cumulative_electric_energy_kilowatt"),
+		"The cumulative electric energy of the remo e lite",
+		[]string{"name", "id"}, nil,
+	)
+
+	measuredInstantaneousEnergy = prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, "", "measured_instantaneous_energy_watt"),
+		"The measured instantaneous energy of the remo e lite",
+		[]string{"name", "id"}, nil,
+	)
+
 	rateLimitLimit = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "x_rate_limit_limit"),
 		"The rate limit for the remo API",
@@ -63,7 +75,7 @@ var (
 		Name:      "http_requests_total",
 		Help:      "The total number of requests labeled by response code",
 	},
-		[]string{"code"},
+		[]string{"code", "api"},
 	)
 )
 
@@ -74,11 +86,9 @@ type Exporter struct {
 
 // NewExporter returns an initialized exporter
 func NewExporter(config *config.Config, client RemoGatherer) (*Exporter, error) {
-
 	return &Exporter{
 		client: client,
 	}, nil
-
 }
 
 // Describe is to describe the metrics for Prometheus
@@ -87,6 +97,8 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 	ch <- humidity
 	ch <- illumination
 	ch <- motion
+	ch <- cumulativeElectricEnergy
+	ch <- measuredInstantaneousEnergy
 	ch <- rateLimitLimit
 	ch <- rateLimitReset
 	ch <- rateLimitRemaining
@@ -95,13 +107,25 @@ func (e *Exporter) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect collects data to be consumed by prometheus
 func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
-	data, err := e.client.GetDevices()
+	devices, err := e.client.GetDevices()
 	if err != nil {
 		log.Errorf("Fetching device stats failed: %v", err)
 		return
 	}
 
-	err = e.processMetrics(data, ch)
+	appliances := &types.GetAppliancesResult{}
+	for _, dev := range devices.Devices {
+		if dev.IsRemoElite() {
+			appliances, err = e.client.GetAppliances()
+			if err != nil {
+				log.Errorf("Fetching appliances stats failed: %v", err)
+				return
+			}
+			break
+		}
+	}
+
+	err = e.processMetrics(devices, appliances, ch)
 	if err != nil {
 		log.Errorf("Processing the metrics failed: %v", err)
 		return
@@ -109,15 +133,33 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 
 }
 
-func (e *Exporter) processMetrics(devicesResult *types.GetDevicesResult, ch chan<- prometheus.Metric) error {
+func (e *Exporter) processMetrics(devicesResult *types.GetDevicesResult, appliancesResult *types.GetAppliancesResult, ch chan<- prometheus.Metric) error {
 	for _, d := range devicesResult.Devices {
+		if !d.IsRemo() {
+			continue
+		}
 		ch <- prometheus.MustNewConstMetric(temperature, prometheus.GaugeValue, d.NewestEvents.Temperature.Value, d.Name, d.ID)
 		ch <- prometheus.MustNewConstMetric(humidity, prometheus.GaugeValue, d.NewestEvents.Humidity.Value, d.Name, d.ID)
 		ch <- prometheus.MustNewConstMetric(illumination, prometheus.GaugeValue, d.NewestEvents.Illumination.Value, d.Name, d.ID)
 		ch <- prometheus.MustNewConstMetric(motion, prometheus.GaugeValue, float64(d.NewestEvents.Motion.CreatedAt.Unix()), d.Name, d.ID)
 	}
 
-	if devicesResult.Meta != nil {
+	sms := getSmartMeters(appliancesResult.Appliances)
+	for _, sm := range sms {
+		info, err := energyInfo(sm)
+		if err != nil {
+			log.Errorf("failed to get EnergyInfo: %w", err)
+			continue
+		}
+		ch <- prometheus.MustNewConstMetric(cumulativeElectricEnergy, prometheus.CounterValue, info.CumulativeElectricEnergy(), sm.Device.Name, sm.Device.ID)
+		ch <- prometheus.MustNewConstMetric(measuredInstantaneousEnergy, prometheus.GaugeValue, float64(info.MeasuredInstantaneous), sm.Device.Name, sm.Device.ID)
+	}
+
+	if appliancesResult.Meta != nil {
+		ch <- prometheus.MustNewConstMetric(rateLimitLimit, prometheus.GaugeValue, appliancesResult.Meta.RateLimitLimit)
+		ch <- prometheus.MustNewConstMetric(rateLimitRemaining, prometheus.GaugeValue, appliancesResult.Meta.RateLimitRemaining)
+		ch <- prometheus.MustNewConstMetric(rateLimitReset, prometheus.GaugeValue, appliancesResult.Meta.RateLimitReset)
+	} else if devicesResult.Meta != nil {
 		ch <- prometheus.MustNewConstMetric(rateLimitLimit, prometheus.GaugeValue, devicesResult.Meta.RateLimitLimit)
 		ch <- prometheus.MustNewConstMetric(rateLimitRemaining, prometheus.GaugeValue, devicesResult.Meta.RateLimitRemaining)
 		ch <- prometheus.MustNewConstMetric(rateLimitReset, prometheus.GaugeValue, devicesResult.Meta.RateLimitReset)
@@ -126,10 +168,16 @@ func (e *Exporter) processMetrics(devicesResult *types.GetDevicesResult, ch chan
 	if devicesResult.StatusCode > 0 {
 		if !devicesResult.IsCache {
 			// increment the counter only if it's not a cache
-			httpRequestsTotal.WithLabelValues(strconv.Itoa(devicesResult.StatusCode)).Inc()
+			httpRequestsTotal.WithLabelValues(strconv.Itoa(devicesResult.StatusCode), "devices").Inc()
 		}
-		httpRequestsTotal.Collect(ch)
 	}
+	if appliancesResult.StatusCode > 0 {
+		if !appliancesResult.IsCache {
+			// increment the counter only if it's not a cache
+			httpRequestsTotal.WithLabelValues(strconv.Itoa(appliancesResult.StatusCode), "appliances").Inc()
+		}
+	}
+	httpRequestsTotal.Collect(ch)
 
 	return nil
 }

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -39,7 +39,7 @@ func readGauge(g prometheus.Metric) metricResult {
 	}
 }
 
-func readCounter(g prometheus.Counter) metricResult {
+func readCounter(g prometheus.Metric) metricResult {
 	m := &dto.Metric{}
 	g.Write(m)
 
@@ -81,13 +81,17 @@ var _ = Describe("Exporter", func() {
 			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_motion", help: "The motion of the remo device", constLabels: {}, variableLabels: [name id]}`))
 			d = (<-ch)
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_cumulative_electric_energy_kilowatt", help: "The cumulative electric energy of the remo e lite", constLabels: {}, variableLabels: [name id]}`))
+			d = (<-ch)
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_measured_instantaneous_energy_watt", help: "The measured instantaneous energy of the remo e lite", constLabels: {}, variableLabels: [name id]}`))
+			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_x_rate_limit_limit", help: "The rate limit for the remo API", constLabels: {}, variableLabels: []}`))
 			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_x_rate_limit_reset", help: "The time in which the rate limit for the remo API will be reset", constLabels: {}, variableLabels: []}`))
 			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_x_rate_limit_remaining", help: "The remaining number of request for the remo API", constLabels: {}, variableLabels: []}`))
 			d = (<-ch)
-			Expect(d.String()).To(Equal(`Desc{fqName: "remo_http_requests_total", help: "The total number of requests labeled by response code", constLabels: {}, variableLabels: [code]}`))
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_http_requests_total", help: "The total number of requests labeled by response code", constLabels: {}, variableLabels: [code api]}`))
 		})
 	})
 
@@ -96,8 +100,9 @@ var _ = Describe("Exporter", func() {
 			remoClient := mocks.NewMockRemoGatherer(mockCtrl)
 
 			device := &types.Device{
-				Name: "some_device_name",
-				ID:   "some_device_id",
+				Name:            "some_device_name",
+				ID:              "some_device_id",
+				FirmwareVersion: "Remo/1.0.77-g808448c",
 				NewestEvents: &types.Event{
 					Temperature: &types.SensorValue{
 						Value: 50.0,
@@ -172,6 +177,119 @@ var _ = Describe("Exporter", func() {
 			counter := (<-ch).(prometheus.Counter)
 			m2 = readCounter(counter)
 			Expect(m2.labels["code"]).To(Equal(strconv.Itoa(result.StatusCode)))
+		})
+
+		It("should collect metrics from Remo E lite", func() {
+			remoClient := mocks.NewMockRemoGatherer(mockCtrl)
+
+			device := &types.Device{
+				Name:            "some_device_name",
+				ID:              "some_device_id",
+				FirmwareVersion: "Remo-E-lite/1.1.2",
+			}
+			appliance := &types.Appliance{
+				ID:   "some_appliance_id",
+				Type: "EL_SMART_METER",
+				Device: &types.Device{
+					Name: "some_device_name",
+					ID:   "some_device_id",
+				},
+				SmartMeter: &types.SmartMeter{
+					EchonetliteProperties: []*types.EchonetliteProperty{
+						{
+							Name: "coefficient",
+							Epc:  211,
+							Val:  "1",
+						},
+						{
+							Name: "cumulative_electric_energy_effective_digits",
+							Epc:  215,
+							Val:  "6",
+						},
+						{
+							Name: "normal_direction_cumulative_electric_energy",
+							Epc:  224,
+							Val:  "50851",
+						},
+						{
+							Name: "cumulative_electric_energy_unit",
+							Epc:  225,
+							Val:  "1",
+						},
+						{
+							Name: "reverse_direction_cumulative_electric_energy",
+							Epc:  227,
+							Val:  "11",
+						},
+						{
+							Name: "measured_instantaneous",
+							Epc:  231,
+							Val:  "568",
+						},
+					},
+				},
+			}
+			devResult := &types.GetDevicesResult{
+				StatusCode: 200,
+				Devices:    []*types.Device{device},
+				Meta: &types.Meta{
+					RateLimitLimit:     30.0,
+					RateLimitRemaining: 29.0,
+					RateLimitReset:     1532778912,
+				},
+				IsCache: false,
+			}
+			appResult := &types.GetAppliancesResult{
+				StatusCode: 200,
+				Appliances: []*types.Appliance{appliance},
+				Meta: &types.Meta{
+					RateLimitLimit:     30.0,
+					RateLimitRemaining: 28.0,
+					RateLimitReset:     1532788912,
+				},
+				IsCache: false,
+			}
+			remoClient.EXPECT().GetDevices().Return(devResult, nil)
+			remoClient.EXPECT().GetAppliances().Return(appResult, nil)
+
+			c, _ := config.NewConfig(mockReader)
+			e, err := NewExporter(c, remoClient)
+			Expect(err).Should(BeNil())
+
+			ch := make(chan prometheus.Metric)
+			defer close(ch)
+
+			go e.Collect(ch)
+
+			m := (<-ch).(prometheus.Metric)
+			m2 := readCounter(m)
+			Expect(m2.value).To(BeNumerically("==", 5084))
+			Expect(m2.labels["name"]).To(Equal(appliance.Device.Name))
+			Expect(m2.labels["id"]).To(Equal(appliance.Device.ID))
+
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(BeNumerically("==", 568))
+			Expect(m2.labels["name"]).To(Equal(appliance.Device.Name))
+			Expect(m2.labels["id"]).To(Equal(appliance.Device.ID))
+
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(Equal(appResult.Meta.RateLimitLimit))
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(Equal(appResult.Meta.RateLimitRemaining))
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(Equal(appResult.Meta.RateLimitReset))
+
+			counter := (<-ch).(prometheus.Counter)
+			m2 = readCounter(counter)
+			Expect(m2.labels["code"]).To(Equal(strconv.Itoa(devResult.StatusCode)))
+
+			counter = (<-ch).(prometheus.Counter)
+			m2 = readCounter(counter)
+			Expect(m2.labels["code"]).To(Equal(strconv.Itoa(appResult.StatusCode)))
 		})
 	})
 })

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -81,9 +81,17 @@ var _ = Describe("Exporter", func() {
 			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_motion", help: "The motion of the remo device", constLabels: {}, variableLabels: [name id]}`))
 			d = (<-ch)
-			Expect(d.String()).To(Equal(`Desc{fqName: "remo_cumulative_electric_energy_kilowatt", help: "The cumulative electric energy of the remo e lite", constLabels: {}, variableLabels: [name id]}`))
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_normal_direction_cumulative_electric_energy", help: "The raw value for cumulative electric energy in normal direction", constLabels: {}, variableLabels: [name id]}`))
 			d = (<-ch)
-			Expect(d.String()).To(Equal(`Desc{fqName: "remo_measured_instantaneous_energy_watt", help: "The measured instantaneous energy of the remo e lite", constLabels: {}, variableLabels: [name id]}`))
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_reverse_direction_cumulative_electric_energy", help: "The raw value for cumulative electric energy in reverse direction", constLabels: {}, variableLabels: [name id]}`))
+			d = (<-ch)
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_coefficient", help: "The coefficient for cumulative electric energy", constLabels: {}, variableLabels: [name id]}`))
+			d = (<-ch)
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_cumulative_electric_energy_unit_kilowatt_hour", help: "The unit in kWh for cumulative electric energy", constLabels: {}, variableLabels: [name id]}`))
+			d = (<-ch)
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_cumulative_electric_energy_effective_digits", help: "The number of effective digits for cumulative electric energy", constLabels: {}, variableLabels: [name id]}`))
+			d = (<-ch)
+			Expect(d.String()).To(Equal(`Desc{fqName: "remo_measured_instantaneous_energy_watt", help: "The measured instantaneous energy in W", constLabels: {}, variableLabels: [name id]}`))
 			d = (<-ch)
 			Expect(d.String()).To(Equal(`Desc{fqName: "remo_x_rate_limit_limit", help: "The rate limit for the remo API", constLabels: {}, variableLabels: []}`))
 			d = (<-ch)
@@ -130,6 +138,7 @@ var _ = Describe("Exporter", func() {
 				IsCache: false,
 			}
 			remoClient.EXPECT().GetDevices().Return(result, nil)
+			remoClient.EXPECT().GetAppliances().Return(&types.GetAppliancesResult{}, nil)
 
 			c, _ := config.NewConfig(mockReader)
 			e, err := NewExporter(c, remoClient)
@@ -263,7 +272,31 @@ var _ = Describe("Exporter", func() {
 
 			m := (<-ch).(prometheus.Metric)
 			m2 := readCounter(m)
-			Expect(m2.value).To(BeNumerically("==", 5084))
+			Expect(m2.value).To(BeNumerically("==", 50851))
+			Expect(m2.labels["name"]).To(Equal(appliance.Device.Name))
+			Expect(m2.labels["id"]).To(Equal(appliance.Device.ID))
+
+			m = (<-ch).(prometheus.Metric)
+			m2 = readCounter(m)
+			Expect(m2.value).To(BeNumerically("==", 11))
+			Expect(m2.labels["name"]).To(Equal(appliance.Device.Name))
+			Expect(m2.labels["id"]).To(Equal(appliance.Device.ID))
+
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(BeNumerically("==", 1))
+			Expect(m2.labels["name"]).To(Equal(appliance.Device.Name))
+			Expect(m2.labels["id"]).To(Equal(appliance.Device.ID))
+
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(BeNumerically("==", 0.1))
+			Expect(m2.labels["name"]).To(Equal(appliance.Device.Name))
+			Expect(m2.labels["id"]).To(Equal(appliance.Device.ID))
+
+			m = (<-ch).(prometheus.Metric)
+			m2 = readGauge(m)
+			Expect(m2.value).To(BeNumerically("==", 6))
 			Expect(m2.labels["name"]).To(Equal(appliance.Device.Name))
 			Expect(m2.labels["id"]).To(Equal(appliance.Device.ID))
 

--- a/exporter/remo.go
+++ b/exporter/remo.go
@@ -20,22 +20,31 @@ const (
 // RemoGatherer gathers stats from the remo api
 type RemoGatherer interface {
 	GetDevices() (*types.GetDevicesResult, error)
+	GetAppliances() (*types.GetAppliancesResult, error)
 }
 
-type Metrics struct {
+type DevicesMetrics struct {
 	StatusCode int
 	Meta       *types.Meta
 	Devices    []*types.Device
 }
 
+type AppliancesMetrics struct {
+	StatusCode int
+	Meta       *types.Meta
+	Appliances []*types.Appliance
+}
+
 // RemoClient is a http client who requests resources from the Remo API
 type RemoClient struct {
-	authClient               authHttp.AuthHttpDoer
-	baseURL                  string
-	oauthToken               string
-	cachedMetrics            *Metrics
-	cacheInvalidationSeconds int
-	cacheExpirationTimestamp int
+	authClient                         authHttp.AuthHttpDoer
+	baseURL                            string
+	oauthToken                         string
+	cachedDevicesMetrics               *DevicesMetrics
+	cachedAppliancesMetrics            *AppliancesMetrics
+	cacheInvalidationSeconds           int
+	cacheDevicesExpirationTimestamp    int
+	cacheAppliancesExpirationTimestamp int
 }
 
 // NewRemoClient will return an initialized RemoClient
@@ -45,7 +54,8 @@ func NewRemoClient(config *config.Config, authClient authHttp.AuthHttpDoer) (*Re
 		baseURL:                  config.APIBaseURL,
 		oauthToken:               config.OAuthToken,
 		cacheInvalidationSeconds: config.CacheInvalidationSeconds,
-		cachedMetrics:            &Metrics{},
+		cachedDevicesMetrics:     &DevicesMetrics{},
+		cachedAppliancesMetrics:  &AppliancesMetrics{},
 	}, nil
 }
 
@@ -82,12 +92,12 @@ func getMetaStats(header http.Header) *types.Meta {
 func (c *RemoClient) GetDevices() (*types.GetDevicesResult, error) {
 	now := int(time.Now().Unix())
 
-	if now < c.cacheExpirationTimestamp {
-		log.Infof("Returning cache. Cache valid for %d seconds", c.cacheExpirationTimestamp-now)
+	if now < c.cacheDevicesExpirationTimestamp {
+		log.Infof("GetDevices: Returning cache. Cache valid for %d seconds", c.cacheDevicesExpirationTimestamp-now)
 		result := &types.GetDevicesResult{
-			StatusCode: c.cachedMetrics.StatusCode,
-			Meta:       c.cachedMetrics.Meta,
-			Devices:    c.cachedMetrics.Devices,
+			StatusCode: c.cachedDevicesMetrics.StatusCode,
+			Meta:       c.cachedDevicesMetrics.Meta,
+			Devices:    c.cachedDevicesMetrics.Devices,
 			IsCache:    true,
 		}
 		return result, nil
@@ -110,8 +120,8 @@ func (c *RemoClient) GetDevices() (*types.GetDevicesResult, error) {
 		json.Unmarshal(bodyBytes, &data)
 
 		// only update invalidation time on successful requests
-		c.cacheExpirationTimestamp = now + c.cacheInvalidationSeconds
-		log.Infof("Fetched data from the remote API. Caching until %d", c.cacheExpirationTimestamp)
+		c.cacheDevicesExpirationTimestamp = now + c.cacheInvalidationSeconds
+		log.Infof("GetDevices: Fetched data from the remote API. Caching until %d", c.cacheDevicesExpirationTimestamp)
 	}
 
 	meta := getMetaStats(resp.Header)
@@ -122,9 +132,62 @@ func (c *RemoClient) GetDevices() (*types.GetDevicesResult, error) {
 		IsCache:    false,
 	}
 
-	c.cachedMetrics.StatusCode = result.StatusCode
-	c.cachedMetrics.Meta = result.Meta
-	c.cachedMetrics.Devices = result.Devices
+	c.cachedDevicesMetrics.StatusCode = result.StatusCode
+	c.cachedDevicesMetrics.Meta = result.Meta
+	c.cachedDevicesMetrics.Devices = result.Devices
+
+	return result, nil
+}
+
+func (c *RemoClient) GetAppliances() (*types.GetAppliancesResult, error) {
+	now := int(time.Now().Unix())
+
+	if now < c.cacheAppliancesExpirationTimestamp {
+		log.Infof("GetAppliances: Returning cache. Cache valid for %d seconds", c.cacheAppliancesExpirationTimestamp-now)
+		result := &types.GetAppliancesResult{
+			StatusCode: c.cachedAppliancesMetrics.StatusCode,
+			Meta:       c.cachedAppliancesMetrics.Meta,
+			Appliances: c.cachedAppliancesMetrics.Appliances,
+			IsCache:    true,
+		}
+		return result, nil
+	}
+
+	url := c.baseURL + "/1/appliances"
+	resp, err := c.authClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	var data []*types.Appliance
+	if resp.StatusCode == 200 {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(bodyBytes, &data)
+		if err != nil {
+			return nil, err
+		}
+
+		// only update invalidation time on successful requests
+		c.cacheAppliancesExpirationTimestamp = now + c.cacheInvalidationSeconds
+		log.Infof("GetAppliances: Fetched data from the remote API. Caching until %d", c.cacheAppliancesExpirationTimestamp)
+	}
+
+	meta := getMetaStats(resp.Header)
+	result := &types.GetAppliancesResult{
+		StatusCode: resp.StatusCode,
+		Meta:       meta,
+		Appliances: data,
+		IsCache:    false,
+	}
+
+	c.cachedAppliancesMetrics.StatusCode = result.StatusCode
+	c.cachedAppliancesMetrics.Meta = result.Meta
+	c.cachedAppliancesMetrics.Appliances = result.Appliances
 
 	return result, nil
 }

--- a/exporter/smart_meter.go
+++ b/exporter/smart_meter.go
@@ -1,0 +1,108 @@
+package exporter
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/kenfdev/remo-exporter/types"
+)
+
+const (
+	EpcNormalDirectionCumulativeElectricEnergy  = 224
+	EpcReverseDirectionCumulativeElectricEnergy = 227
+	EpcCoefficient                              = 211
+	EpcCumulativeElectricEnergyUnit             = 225
+	EpcCumulativeElectricEnergyEffectiveDigits  = 215
+	EpcMeasuredInstantaneous                    = 231
+)
+
+type EnergyInfo struct {
+	NormalEnergy          int
+	ReverseEnergy         int
+	Coefficient           int
+	EnergyUnit            float64
+	EffectiveDigits       int
+	MeasuredInstantaneous int
+}
+
+func (i EnergyInfo) CumulativeElectricEnergy() float64 {
+	return float64((i.NormalEnergy-i.ReverseEnergy)*i.Coefficient) * i.EnergyUnit
+}
+
+func getSmartMeters(apps []*types.Appliance) []*types.Appliance {
+	smartMeters := make([]*types.Appliance, 0)
+	for _, app := range apps {
+		if app.Type == "EL_SMART_METER" {
+			smartMeters = append(smartMeters, app)
+		}
+	}
+	return smartMeters
+}
+
+func energyInfo(sm *types.Appliance) (*EnergyInfo, error) {
+	if sm.SmartMeter == nil {
+		return nil, fmt.Errorf("'%s' does not have smart_meter field", sm.Device.Name)
+	}
+	if len(sm.SmartMeter.EchonetliteProperties) != 6 {
+		return nil, fmt.Errorf("'%s' has incorrect echonetlite_properties", sm.Device.Name)
+	}
+	var info EnergyInfo
+	var err error
+	for _, p := range sm.SmartMeter.EchonetliteProperties {
+		switch p.Epc {
+		case EpcNormalDirectionCumulativeElectricEnergy:
+			info.NormalEnergy, err = strconv.Atoi(p.Val)
+			if err != nil {
+				return nil, err
+			}
+		case EpcReverseDirectionCumulativeElectricEnergy:
+			info.ReverseEnergy, err = strconv.Atoi(p.Val)
+			if err != nil {
+				return nil, err
+			}
+		case EpcCoefficient:
+			info.Coefficient, err = strconv.Atoi(p.Val)
+			if err != nil {
+				return nil, err
+			}
+		case EpcCumulativeElectricEnergyUnit:
+			unit, err := strconv.Atoi(p.Val)
+			if err != nil {
+				return nil, err
+			}
+			switch unit {
+			case 0:
+				info.EnergyUnit = 1
+			case 1:
+				info.EnergyUnit = 0.1
+			case 2:
+				info.EnergyUnit = 0.01
+			case 3:
+				info.EnergyUnit = 0.001
+			case 4:
+				info.EnergyUnit = 0.0001
+			case 10:
+				info.EnergyUnit = 10
+			case 11:
+				info.EnergyUnit = 100
+			case 12:
+				info.EnergyUnit = 1000
+			case 13:
+				info.EnergyUnit = 10000
+			default:
+				return nil, fmt.Errorf("invalid CumulativeElectricEnergyUnit value: %d", unit)
+			}
+		case EpcCumulativeElectricEnergyEffectiveDigits:
+			info.EffectiveDigits, err = strconv.Atoi(p.Val)
+			if err != nil {
+				return nil, err
+			}
+		case EpcMeasuredInstantaneous:
+			info.MeasuredInstantaneous, err = strconv.Atoi(p.Val)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return &info, nil
+}

--- a/exporter/smart_meter.go
+++ b/exporter/smart_meter.go
@@ -25,10 +25,6 @@ type EnergyInfo struct {
 	MeasuredInstantaneous int
 }
 
-func (i EnergyInfo) CumulativeElectricEnergy() float64 {
-	return float64((i.NormalEnergy-i.ReverseEnergy)*i.Coefficient) * i.EnergyUnit
-}
-
 func getSmartMeters(apps []*types.Appliance) []*types.Appliance {
 	smartMeters := make([]*types.Appliance, 0)
 	for _, app := range apps {
@@ -42,9 +38,6 @@ func getSmartMeters(apps []*types.Appliance) []*types.Appliance {
 func energyInfo(sm *types.Appliance) (*EnergyInfo, error) {
 	if sm.SmartMeter == nil {
 		return nil, fmt.Errorf("'%s' does not have smart_meter field", sm.Device.Name)
-	}
-	if len(sm.SmartMeter.EchonetliteProperties) != 6 {
-		return nil, fmt.Errorf("'%s' has incorrect echonetlite_properties", sm.Device.Name)
 	}
 	var info EnergyInfo
 	var err error

--- a/mocks/remo.go
+++ b/mocks/remo.go
@@ -5,9 +5,10 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	types "github.com/kenfdev/remo-exporter/types"
-	reflect "reflect"
 )
 
 // MockRemoGatherer is a mock of RemoGatherer interface
@@ -41,7 +42,20 @@ func (m *MockRemoGatherer) GetDevices() (*types.GetDevicesResult, error) {
 	return ret0, ret1
 }
 
+// GetAppliances mocks base method
+func (m *MockRemoGatherer) GetAppliances() (*types.GetAppliancesResult, error) {
+	ret := m.ctrl.Call(m, "GetAppliances")
+	ret0, _ := ret[0].(*types.GetAppliancesResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
 // GetDevices indicates an expected call of GetDevices
 func (mr *MockRemoGathererMockRecorder) GetDevices() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDevices", reflect.TypeOf((*MockRemoGatherer)(nil).GetDevices))
+}
+
+// GetAppliances indicates an expected call of GetAppliances
+func (mr *MockRemoGathererMockRecorder) GetAppliances() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAppliances", reflect.TypeOf((*MockRemoGatherer)(nil).GetAppliances))
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1,6 +1,9 @@
 package types
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type User struct {
 	ID        string `json:"id"`
@@ -31,6 +34,14 @@ type Device struct {
 	NewestEvents      *Event  `json:"newest_events"`
 }
 
+func (d Device) IsRemo() bool {
+	return strings.HasPrefix(d.FirmwareVersion, "Remo/")
+}
+
+func (d Device) IsRemoElite() bool {
+	return strings.HasPrefix(d.FirmwareVersion, "Remo-E-lite/")
+}
+
 type Meta struct {
 	RateLimitLimit     float64
 	RateLimitReset     float64
@@ -43,4 +54,39 @@ type GetDevicesResult struct {
 	Meta       *Meta
 	Devices    []*Device
 	IsCache    bool
+}
+
+type GetAppliancesResult struct {
+	StatusCode int
+	Meta       *Meta
+	Appliances []*Appliance
+	IsCache    bool
+}
+
+type Appliance struct {
+	ID         string      `json:"id"`
+	Device     *Device     `json:"device"`
+	Model      *Model      `json:"model"`
+	Type       string      `json:"type"`
+	Nickname   string      `json:"nickname"`
+	Image      string      `json:"image"`
+	SmartMeter *SmartMeter `json:"smart_meter"`
+}
+
+type Model struct {
+	ID           string `json:"id"`
+	Manufacturer string `json:"manufacturer"`
+	Name         string `json:"name"`
+	Image        string `json:"image"`
+}
+
+type SmartMeter struct {
+	EchonetliteProperties []*EchonetliteProperty `json:"echonetlite_properties"`
+}
+
+type EchonetliteProperty struct {
+	Name      string    `json:"name"`
+	Epc       int       `json:"epc"`
+	Val       string    `json:"val"`
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"strings"
 	"time"
 )
 
@@ -32,14 +31,6 @@ type Device struct {
 	HumidityOffset    int     `json:"humidity_offset"`
 	Users             []*User `json:"users"`
 	NewestEvents      *Event  `json:"newest_events"`
-}
-
-func (d Device) IsRemo() bool {
-	return strings.HasPrefix(d.FirmwareVersion, "Remo/")
-}
-
-func (d Device) IsRemoElite() bool {
-	return strings.HasPrefix(d.FirmwareVersion, "Remo-E-lite/")
 }
 
 type Meta struct {


### PR DESCRIPTION
## Description

This PR adds a feature to support the Nature Remo E lite.
This feature allows remo-exporter to expose cumulative electric energy and measured instantaneous electric energy.

The cumulative electric energy is derived from the following formula.
https://developer.nature.global/jp/how-to-calculate-energy-data-from-smart-meter-values

## Related Issue

This PR will fix #17 

## Motivation and Context

I want to visualize electric energy with Remo E lite.

## How Has This Been Tested?

I added some test cases in remo_test.go and exporter_test.go.

## Screenshots (if appropriate):
![remo](https://user-images.githubusercontent.com/586654/82547438-af7ea880-9b94-11ea-9919-9c64cfc7d215.png)

