### PR TITLE
reuse http.Client

### DIFF
--- a/http/authhttp.go
+++ b/http/authhttp.go
@@ -9,18 +9,18 @@ type AuthHttpDoer interface {
 }
 
 type AuthHttpClient struct {
-	token string
+	token  string
+	client *http.Client
 }
 
 func NewAuthHttpClient(token string) *AuthHttpClient {
 	return &AuthHttpClient{
-		token: token,
+		token:  token,
+		client: &http.Client{},
 	}
 }
 
 func (c *AuthHttpClient) Get(url string) (*http.Response, error) {
-	var client http.Client
-
 	req, err := http.NewRequest("GET", url, nil)
 	req.Header.Add("Authorization", "Bearer "+c.token)
 
@@ -28,5 +28,5 @@ func (c *AuthHttpClient) Get(url string) (*http.Response, error) {
 		return nil, err
 	}
 
-	return client.Do(req)
+	return c.client.Do(req)
 }

--- a/http/authhttp_test.go
+++ b/http/authhttp_test.go
@@ -1,0 +1,34 @@
+package http_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	authhttp "github.com/kenfdev/remo-exporter/http"
+)
+
+func TestAuthHttpClient(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		if want, got := "Bearer dummy_token", r.Header.Get("Authorization"); want != got {
+			t.Errorf("unexpected authz header want=%s got=%s", want, got)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	c := authhttp.NewAuthHttpClient("dummy_token")
+	resp, err := c.Get(ts.URL + "/test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if want, got := http.StatusOK, resp.StatusCode; want != got {
+		t.Fatalf("unexpected status code want=%d got=%d", want, got)
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Reuse http.Client without initializing each time.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

https://pkg.go.dev/net/http#Client

> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed. Clients are safe for concurrent use by multiple goroutines.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Add a unit test.

## Screenshots (if appropriate):
